### PR TITLE
fix: change stryker.net version to 3.7.1

### DIFF
--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install .NET Stryker
         shell: bash
         run: |
-          dotnet tool install dotnet-stryker --tool-path ../tools
+          dotnet tool install dotnet-stryker --tool-path ../tools --version 3.7.1
       - name: Analyze Testably.Architecture.Rules
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
Fix stryker version to `3.7.1` due to https://github.com/stryker-mutator/stryker-net/issues/2499.