### PR TITLE
feat: add generic method parameter requirements

### DIFF
--- a/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
@@ -176,6 +176,5 @@ public static class TypeExtensions
 	/// <param name="type">The <see cref="Type" />.</param>
 	/// <remarks>https://stackoverflow.com/a/1175901</remarks>
 	public static bool IsStatic(this Type type)
-		=> type.IsAbstract && type.IsSealed && !type.IsInterface &&
-		   !type.GetConstructors().Any(m => m.IsPublic);
+		=> !type.IsInterface && type.IsAbstract && type.IsSealed;
 }

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnMethodExtensions.HaveParameter.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnMethodExtensions.HaveParameter.cs
@@ -5,6 +5,32 @@ namespace Testably.Architecture.Rules;
 public static partial class RequirementOnMethodExtensions
 {
 	/// <summary>
+	///     The parameters of the <see cref="MethodInfo" /> should satisfy the given <paramref name="parameterFilter" />.
+	/// </summary>
+	public static IRequirementResult<MethodInfo> ShouldHave(
+		this IRequirement<MethodInfo> @this,
+		IUnorderedParameterFilterResult parameterFilter)
+	{
+		return @this.ShouldSatisfy(Requirement.ForMethod(
+			m => parameterFilter.Apply(m.GetParameters()),
+			method => new MethodTestError(method,
+				$"The method '{method.Name}' should have a parameter which {parameterFilter}.")));
+	}
+
+	/// <summary>
+	///     The parameters of the <see cref="MethodInfo" /> should satisfy the given <paramref name="parameterFilter" />.
+	/// </summary>
+	public static IRequirementResult<MethodInfo> ShouldHave(
+		this IRequirement<MethodInfo> @this,
+		IOrderedParameterFilterResult parameterFilter)
+	{
+		return @this.ShouldSatisfy(Requirement.ForMethod(
+			m => parameterFilter.Apply(m.GetParameters()),
+			method => new MethodTestError(method,
+				$"The method '{method.Name}' should have parameters whose {parameterFilter.FriendlyName()}.")));
+	}
+
+	/// <summary>
 	///     The <see cref="MethodInfo" /> should have no parameters.
 	/// </summary>
 	public static IRequirementResult<MethodInfo> ShouldHaveNoParameters(


### PR DESCRIPTION
Add generic `Parameters` requirements on methods.
Re-Use the `IOrderedParameters` and `IUnorderedParameters` filter and allow specifying e.g.
`.ShouldHave(Parameters.Any.OfType<CancellationToken>())` as a requirement