### PR TITLE
feat: add WithReturnType filter for methods and NameMatches requirements

### DIFF
--- a/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
@@ -111,14 +111,12 @@ public static class TypeExtensions
 			return false;
 		}
 
-		Type currentType = type.IsGenericType
-			? type.GetGenericTypeDefinition()
-			: type;
+		Type currentType = type;
 
 		int level = 0;
 		while (currentType != typeof(object))
 		{
-			if (parentType == currentType)
+			if (parentType.IsEqualTo(currentType))
 			{
 				return true;
 			}
@@ -138,12 +136,51 @@ public static class TypeExtensions
 				break;
 			}
 
-			currentType = currentType.BaseType.IsGenericType
-				? currentType.BaseType.GetGenericTypeDefinition()
-				: currentType.BaseType;
+			currentType = currentType.BaseType;
 		}
 
 		return false;
+	}
+
+	/// <summary>
+	///     Determines whether the current <see cref="Type" /> is the same type as the <paramref name="other" />.<br />
+	///     Generic types are considered equal, if either one or both are open generics or the generic argument types
+	///     themselves are equal.
+	/// </summary>
+	/// <param name="type">The <see cref="Type" />.</param>
+	/// <param name="other">The other <see cref="Type" />.</param>
+	public static bool IsEqualTo(
+		this Type type,
+		Type other)
+	{
+		if (type.IsGenericType != other.IsGenericType)
+		{
+			return false;
+		}
+
+		if (type.IsGenericType)
+		{
+			if (type.GetGenericTypeDefinition() == other.GetGenericTypeDefinition())
+			{
+				if (!type.IsGenericTypeDefinition && !other.IsGenericTypeDefinition)
+				{
+					Type[]? typeArguments = type.GetGenericArguments();
+					Type[]? otherArguments = other.GetGenericArguments();
+					for (int i = 0; i < typeArguments.Length; i++)
+					{
+						if (otherArguments.Length >= i &&
+						    !typeArguments[i].IsEqualTo(otherArguments[i]))
+						{
+							return false;
+						}
+					}
+				}
+
+				return true;
+			}
+		}
+
+		return type == other;
 	}
 
 	/// <summary>
@@ -162,7 +199,7 @@ public static class TypeExtensions
 		Type parentType,
 		bool forceDirect = false)
 	{
-		if (type == parentType)
+		if (type.IsEqualTo(parentType))
 		{
 			return true;
 		}

--- a/Source/Testably.Architecture.Rules/Filters/AssemblyFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/AssemblyFilterExtensions.NameMatch.cs
@@ -8,7 +8,7 @@ public static partial class AssemblyFilterExtensions
 	///     Filter for assemblies where the <see cref="AssemblyName.Name" /> does not match the given
 	///     <paramref name="pattern" />.
 	/// </summary>
-	public static IAssemblyFilterResult WhichDoNotMatchName(this IAssemblyFilter @this,
+	public static IAssemblyFilterResult WhichNameDoesNotMatch(this IAssemblyFilter @this,
 		Match pattern,
 		bool ignoreCase = false)
 	{
@@ -18,7 +18,7 @@ public static partial class AssemblyFilterExtensions
 	/// <summary>
 	///     Filter for assemblies where the <see cref="AssemblyName.Name" /> matches the given <paramref name="pattern" />.
 	/// </summary>
-	public static IAssemblyFilterResult WhichMatchName(this IAssemblyFilter @this,
+	public static IAssemblyFilterResult WhichNameMatches(this IAssemblyFilter @this,
 		Match pattern,
 		bool ignoreCase = false)
 	{

--- a/Source/Testably.Architecture.Rules/Filters/EventFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/EventFilterExtensions.NameMatch.cs
@@ -8,7 +8,7 @@ public static partial class EventFilterExtensions
 	///     Filter <see cref="EventInfo" />s where the <see cref="MemberInfo.Name" /> matches the given
 	///     <paramref name="pattern" />.
 	/// </summary>
-	public static IEventFilterResult WithName(
+	public static IEventFilterResult WhichNameMatches(
 		this IEventFilter @this,
 		Match pattern,
 		bool ignoreCase = false)

--- a/Source/Testably.Architecture.Rules/Filters/FieldFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/FieldFilterExtensions.NameMatch.cs
@@ -8,7 +8,7 @@ public static partial class FieldFilterExtensions
 	///     Filter <see cref="FieldInfo" />s where the <see cref="MemberInfo.Name" /> matches the given
 	///     <paramref name="pattern" />.
 	/// </summary>
-	public static IFieldFilterResult WithName(
+	public static IFieldFilterResult WhichNameMatches(
 		this IFieldFilter @this,
 		Match pattern,
 		bool ignoreCase = false)

--- a/Source/Testably.Architecture.Rules/Filters/MethodFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/MethodFilterExtensions.NameMatch.cs
@@ -8,7 +8,7 @@ public static partial class MethodFilterExtensions
 	///     Filter <see cref="MethodInfo" />s where the <see cref="MemberInfo.Name" /> matches the given
 	///     <paramref name="pattern" />.
 	/// </summary>
-	public static IMethodFilterResult WithName(
+	public static IMethodFilterResult WhichNameMatches(
 		this IMethodFilter @this,
 		Match pattern,
 		bool ignoreCase = false)

--- a/Source/Testably.Architecture.Rules/Filters/MethodFilterExtensions.WithReturnType.cs
+++ b/Source/Testably.Architecture.Rules/Filters/MethodFilterExtensions.WithReturnType.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class MethodFilterExtensions
+{
+	/// <summary>
+	///     Filter <see cref="MethodInfo" />s that have a return type of <typeparamref name="TReturnType" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IMethodFilter" />.</param>
+	/// <param name="allowDerivedType">
+	///     <see langword="true" /> to search the inheritance chain to find the attributes; otherwise,
+	///     <see langword="false" />.<br />
+	///     Defaults to <see langword="true" />
+	/// </param>
+	public static WithReturnTypeFilterResult WithReturnType<TReturnType>(
+		this IMethodFilter @this,
+		bool allowDerivedType = false)
+	{
+		return @this.WithReturnType(typeof(TReturnType), allowDerivedType);
+	}
+
+	/// <summary>
+	///     Filter <see cref="MethodInfo" />s that have a return type of <paramref name="returnType" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IMethodFilter" />.</param>
+	/// <param name="returnType">The <see cref="Type" /> of the return value.</param>
+	/// <param name="allowDerivedType">
+	///     <see langword="true" /> to also allow derived types of <paramref name="returnType" />;
+	///     otherwise <see langword="false" />.<br />
+	///     Defaults to <see langword="true" />.
+	/// </param>
+	public static WithReturnTypeFilterResult WithReturnType(
+		this IMethodFilter @this,
+		Type returnType,
+		bool allowDerivedType = false)
+	{
+		WithReturnTypeFilterResult filter = new(
+			@this);
+		filter.OrReturnType(returnType, allowDerivedType);
+		return filter;
+	}
+
+	/// <summary>
+	///     Add additional filters on a <see cref="MethodInfo" /> which has an attribute.
+	/// </summary>
+	public class WithReturnTypeFilterResult : Filter.OnMethod
+	{
+		internal WithReturnTypeFilterResult(
+			IMethodFilter typeFilter) : base(typeFilter)
+		{
+		}
+
+		/// <summary>
+		///     Adds another filter <see cref="MethodInfo" />s for an attribute of type <typeparamref name="TReturnType" />.
+		/// </summary>
+		/// <param name="allowDerivedType">
+		///     <see langword="true" /> to also allow derived types of <typeparamref name="TReturnType" />;
+		///     otherwise <see langword="false" />.<br />
+		///     Defaults to <see langword="true" />.
+		/// </param>
+		public WithReturnTypeFilterResult OrReturnType<TReturnType>(
+			bool allowDerivedType = false)
+		{
+			return OrReturnType(typeof(TReturnType), allowDerivedType);
+		}
+
+		/// <summary>
+		///     Adds another filter <see cref="MethodInfo" />s for an attribute of type <paramref name="returnType" />.
+		/// </summary>
+		/// <param name="returnType">The <see cref="Type" /> of the return value.</param>
+		/// <param name="allowDerivedType">
+		///     <see langword="true" /> to also allow derived types of <paramref name="returnType" />;
+		///     otherwise <see langword="false" />.<br />
+		///     Defaults to <see langword="true" />.
+		/// </param>
+		public WithReturnTypeFilterResult OrReturnType(
+			Type returnType,
+			bool allowDerivedType = false)
+		{
+			Predicates.Add(Filter.FromPredicate<MethodInfo>(
+				method => method.ReturnType.IsOrInheritsFrom(returnType, !allowDerivedType),
+				$"with return type {returnType.Name}"));
+			return this;
+		}
+	}
+}

--- a/Source/Testably.Architecture.Rules/Filters/PropertyFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/PropertyFilterExtensions.NameMatch.cs
@@ -8,7 +8,7 @@ public static partial class PropertyFilterExtensions
 	///     Filter <see cref="PropertyInfo" />s where the <see cref="MemberInfo.Name" /> matches the given
 	///     <paramref name="pattern" />.
 	/// </summary>
-	public static IPropertyFilterResult WithName(
+	public static IPropertyFilterResult WhichNameMatches(
 		this IPropertyFilter @this,
 		Match pattern,
 		bool ignoreCase = false)

--- a/Source/Testably.Architecture.Rules/Filters/TypeFilterExtensions.NameMatch.cs
+++ b/Source/Testably.Architecture.Rules/Filters/TypeFilterExtensions.NameMatch.cs
@@ -7,7 +7,7 @@ public static partial class TypeFilterExtensions
 	/// <summary>
 	///     Filter for types where the <see cref="MemberInfo.Name" /> does not match the given <paramref name="pattern" />.
 	/// </summary>
-	public static ITypeFilterResult WhichDoNotMatchName(this ITypeFilter @this,
+	public static ITypeFilterResult WhichNameDoesNotMatch(this ITypeFilter @this,
 		Match pattern,
 		bool ignoreCase = false)
 	{
@@ -18,7 +18,7 @@ public static partial class TypeFilterExtensions
 	/// <summary>
 	///     Filter for types where the <see cref="MemberInfo.Name" /> matches the given <paramref name="pattern" />.
 	/// </summary>
-	public static ITypeFilterResult WhichMatchName(this ITypeFilter @this,
+	public static ITypeFilterResult WhichNameMatches(this ITypeFilter @this,
 		Match pattern,
 		bool ignoreCase = false)
 	{

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnEventExtensions.MatchName.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnEventExtensions.MatchName.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class RequirementOnEventExtensions
+{
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the @events to match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Event}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<EventInfo> ShouldMatchName(
+		this IRequirement<EventInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForEvent(
+			@event => pattern.Matches(@event.Name, ignoreCase),
+			@event => new EventTestError(@event,
+				$"The event '{@event.Name}' should match pattern '{pattern}'.")));
+
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the @events to not match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Event}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<EventInfo> ShouldNotMatchName(
+		this IRequirement<EventInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForEvent(
+			@event => !pattern.Matches(@event.Name, ignoreCase),
+			@event => new EventTestError(@event,
+				$"The event '{@event.Name}' should not match pattern '{pattern}'.")));
+}

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnEventExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnEventExtensions.cs
@@ -7,7 +7,7 @@ namespace Testably.Architecture.Rules;
 /// <summary>
 ///     Extension events for <see cref="IRequirement{EventInfo}" />.
 /// </summary>
-public static class RequirementOnEventExtensions
+public static partial class RequirementOnEventExtensions
 {
 	/// <summary>
 	///     The <see cref="EventInfo" /> should satisfy the given <paramref name="condition" />.

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnFieldExtensions.MatchName.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnFieldExtensions.MatchName.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class RequirementOnFieldExtensions
+{
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the fields to match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Field}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<FieldInfo> ShouldMatchName(
+		this IRequirement<FieldInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForField(
+			field => pattern.Matches(field.Name, ignoreCase),
+			field => new FieldTestError(field,
+				$"The field '{field.Name}' should match pattern '{pattern}'.")));
+
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the fields to not match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Field}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<FieldInfo> ShouldNotMatchName(
+		this IRequirement<FieldInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForField(
+			field => !pattern.Matches(field.Name, ignoreCase),
+			field => new FieldTestError(field,
+				$"The field '{field.Name}' should not match pattern '{pattern}'.")));
+}

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnFieldExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnFieldExtensions.cs
@@ -7,7 +7,7 @@ namespace Testably.Architecture.Rules;
 /// <summary>
 ///     Extension fields for <see cref="IRequirement{FieldInfo}" />.
 /// </summary>
-public static class RequirementOnFieldExtensions
+public static partial class RequirementOnFieldExtensions
 {
 	/// <summary>
 	///     The <see cref="FieldInfo" /> should satisfy the given <paramref name="condition" />.

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnMethodExtensions.MatchName.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnMethodExtensions.MatchName.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class RequirementOnMethodExtensions
+{
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the methods to match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Method}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<MethodInfo> ShouldMatchName(
+		this IRequirement<MethodInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForMethod(
+			method => pattern.Matches(method.Name, ignoreCase),
+			method => new MethodTestError(method,
+				$"The method '{method.Name}' should match pattern '{pattern}'.")));
+
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the methods to not match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Method}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<MethodInfo> ShouldNotMatchName(
+		this IRequirement<MethodInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForMethod(
+			method => !pattern.Matches(method.Name, ignoreCase),
+			method => new MethodTestError(method,
+				$"The method '{method.Name}' should not match pattern '{pattern}'.")));
+}

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnPropertyExtensions.MatchName.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnPropertyExtensions.MatchName.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class RequirementOnPropertyExtensions
+{
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the propertys to match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Property}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<PropertyInfo> ShouldMatchName(
+		this IRequirement<PropertyInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForProperty(
+			property => pattern.Matches(property.Name, ignoreCase),
+			property => new PropertyTestError(property,
+				$"The property '{property.Name}' should match pattern '{pattern}'.")));
+
+	/// <summary>
+	///     Expect the <see cref="MemberInfo.Name" /> of the propertys to not match the given <paramref name="pattern" />.
+	/// </summary>
+	/// <param name="this">The <see cref="IRequirement{Property}" />.</param>
+	/// <param name="pattern">
+	///     The wildcard condition.
+	///     <para />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </param>
+	/// <param name="ignoreCase">Flag indicating if the comparison should be case sensitive or not.</param>
+	public static IRequirementResult<PropertyInfo> ShouldNotMatchName(
+		this IRequirement<PropertyInfo> @this,
+		Match pattern,
+		bool ignoreCase = false)
+		=> @this.ShouldSatisfy(Requirement.ForProperty(
+			property => !pattern.Matches(property.Name, ignoreCase),
+			property => new PropertyTestError(property,
+				$"The property '{property.Name}' should not match pattern '{pattern}'.")));
+}

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnPropertyExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnPropertyExtensions.cs
@@ -7,7 +7,7 @@ namespace Testably.Architecture.Rules;
 /// <summary>
 ///     Extension properties for <see cref="IRequirement{PropertyInfo}" />.
 /// </summary>
-public static class RequirementOnPropertyExtensions
+public static partial class RequirementOnPropertyExtensions
 {
 	/// <summary>
 	///     The <see cref="PropertyInfo" /> should satisfy the given <paramref name="condition" />.

--- a/Tests/Testably.Architecture.Example.Tests/ExampleTests.cs
+++ b/Tests/Testably.Architecture.Example.Tests/ExampleTests.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Architecture.Example.Tests.TestHelpers;
+﻿using System.Threading.Tasks;
+using Testably.Architecture.Example.Tests.TestHelpers;
 using Testably.Architecture.Rules;
 using Xunit;
 
@@ -6,6 +7,22 @@ namespace Testably.Architecture.Example.Tests;
 
 public sealed class ExampleTests
 {
+	/// <summary>
+	///     Methods that return Task should have Async suffix
+	/// </summary>
+	[Fact]
+	public void AsyncMethodsShouldHaveAsyncSuffix()
+	{
+		IRule rule = Expect.That.Methods
+			.WithReturnType<Task>().OrReturnType(typeof(Task<>))
+			.ShouldMatchName("*Async")
+			.AllowEmpty();
+
+		rule.Check
+			.InTestAssembly()
+			.ThrowIfViolated();
+	}
+
 	/// <summary>
 	///     All test classes should be named with 'Tests' as suffix.
 	///     <para />

--- a/Tests/Testably.Architecture.Rules.Tests/Extensions/TypeExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Extensions/TypeExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿using FluentAssertions;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Testably.Architecture.Rules.Tests.Extensions;
@@ -69,6 +71,36 @@ public sealed class TypeExtensionsTests
 		bool result = sut.InheritsFrom(typeof(TestClassWithAttribute));
 
 		result.Should().BeFalse();
+	}
+
+	[Fact]
+	public void IsEqualTo_DifferentClosedGenericType_ShouldReturnFalse()
+	{
+		Type sut = typeof(Dictionary<int, string>);
+
+		bool result = sut.IsEqualTo(typeof(Dictionary<int, int>));
+
+		result.Should().BeFalse();
+	}
+
+	[Fact]
+	public void IsEqualTo_SameGenericType_OtherOpen_ShouldReturnTrue()
+	{
+		Type sut = typeof(Task<>);
+
+		bool result = sut.IsEqualTo(typeof(Task<int>));
+
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public void IsEqualTo_SameGenericType_TypeOpen_ShouldReturnTrue()
+	{
+		Type sut = typeof(Dictionary<int, string>);
+
+		bool result = sut.IsEqualTo(typeof(Dictionary<,>));
+
+		result.Should().BeTrue();
 	}
 
 	[Fact]

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/AssemblyFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/AssemblyFilterExtensionsTests.NameMatch.cs
@@ -5,7 +5,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 
 public sealed partial class AssemblyFilterExtensionsTests
 {
-	public sealed class MatchNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTABLY.Architecture.RULES", false)]
@@ -16,11 +16,11 @@ public sealed partial class AssemblyFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*s", true)]
 		[InlineData("*rules", false)]
-		public void WhichDoNotMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameDoesNotMatch_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Assemblies
-				.WhichDoNotMatchName(pattern)
+				.WhichNameDoesNotMatch(pattern)
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAssemblyContaining<ArchitectureRuleViolatedException>();
@@ -36,11 +36,11 @@ public sealed partial class AssemblyFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*s", true)]
-		public void WhichDoNotMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameDoesNotMatch_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Assemblies
-				.WhichDoNotMatchName(pattern, true)
+				.WhichNameDoesNotMatch(pattern, true)
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAssemblyContaining<ArchitectureRuleViolatedException>();
@@ -57,11 +57,11 @@ public sealed partial class AssemblyFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*s", true)]
 		[InlineData("*rules", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Assemblies
-				.WhichMatchName(pattern)
+				.WhichNameMatches(pattern)
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAssemblyContaining<ArchitectureRuleViolatedException>();
@@ -77,11 +77,11 @@ public sealed partial class AssemblyFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*s", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Assemblies
-				.WhichMatchName(pattern, true)
+				.WhichNameMatches(pattern, true)
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAssemblyContaining<ArchitectureRuleViolatedException>();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/EventFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/EventFilterExtensionsTests.NameMatch.cs
@@ -5,7 +5,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 
 public sealed partial class EventFilterExtensionsTests
 {
-	public sealed class WithNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTEvent", false)]
@@ -16,12 +16,12 @@ public sealed partial class EventFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*t", true)]
 		[InlineData("*event", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Event.WithName(pattern))
+				.Which(Have.Event.WhichNameMatches(pattern))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();
@@ -37,12 +37,12 @@ public sealed partial class EventFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*t", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Event.WithName(pattern, true))
+				.Which(Have.Event.WhichNameMatches(pattern, true))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/FieldFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/FieldFilterExtensionsTests.NameMatch.cs
@@ -5,7 +5,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 
 public sealed partial class FieldFilterExtensionsTests
 {
-	public sealed class WithNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTField", false)]
@@ -16,12 +16,12 @@ public sealed partial class FieldFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*d", true)]
 		[InlineData("*field", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Field.WithName(pattern))
+				.Which(Have.Field.WhichNameMatches(pattern))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();
@@ -37,12 +37,12 @@ public sealed partial class FieldFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*d", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Field.WithName(pattern, true))
+				.Which(Have.Field.WhichNameMatches(pattern, true))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.NameMatch.cs
@@ -6,7 +6,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 // ReSharper disable UnusedMember.Local
 public sealed partial class MethodFilterExtensionsTests
 {
-	public sealed class WithNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTMethod", false)]
@@ -17,12 +17,12 @@ public sealed partial class MethodFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*d", true)]
 		[InlineData("*method", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Method.WithName(pattern))
+				.Which(Have.Method.WhichNameMatches(pattern))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();
@@ -38,12 +38,12 @@ public sealed partial class MethodFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*d", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Method.WithName(pattern, true))
+				.Which(Have.Method.WhichNameMatches(pattern, true))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
@@ -18,7 +18,7 @@ public sealed partial class MethodFilterExtensionsTests
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Method.WithName(methodName).And
+				.Which(Have.Method.WhichNameMatches(methodName).And
 					.With(Parameters.InOrder.WithName("value1").Then().WithName("value2")))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
@@ -36,7 +36,7 @@ public sealed partial class MethodFilterExtensionsTests
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Method.WithName(methodName).And
+				.Which(Have.Method.WhichNameMatches(methodName).And
 					.With(Parameters.Any.WithName("value1")))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
@@ -56,7 +56,7 @@ public sealed partial class MethodFilterExtensionsTests
 				.WhichAre(typeof(TestClass)).And;
 
 			ITypeFilterResult sut = source
-				.Which(Have.Method.WithName(methodName).And
+				.Which(Have.Method.WhichNameMatches(methodName).And
 					.WithoutParameter());
 
 			ITestResult result = sut.ShouldAlwaysFail()
@@ -77,7 +77,7 @@ public sealed partial class MethodFilterExtensionsTests
 				.WhichAre(typeof(TestClass)).And;
 
 			ITypeFilterResult sut = source
-				.Which(Have.Method.WithName(methodName).And
+				.Which(Have.Method.WhichNameMatches(methodName).And
 					.WithParameters());
 
 			ITestResult result = sut.ShouldAlwaysFail()
@@ -102,7 +102,7 @@ public sealed partial class MethodFilterExtensionsTests
 				.WhichAre(typeof(TestClass)).And;
 
 			ITypeFilterResult sut = source
-				.Which(Have.Method.WithName(methodName).And
+				.Which(Have.Method.WhichNameMatches(methodName).And
 					.WithParameters(minimumCount));
 
 			ITestResult result = sut.ShouldAlwaysFail()

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Filters;
+
+// ReSharper disable UnusedMember.Local
+public sealed partial class MethodFilterExtensionsTests
+{
+	public sealed class WithReturnTypeTests
+	{
+		[Fact]
+		public void OrReturnType_ShouldUseCorrectErrorMessage()
+		{
+			ITestResult result = Expect.That.Types
+				.WhichAre(typeof(BarClass))
+				.Should(Have.Method.WithReturnType<DummyFooClass>())
+				.Check.InAllLoadedAssemblies();
+
+			result.Errors.Length.Should().Be(1);
+			result.Errors[0].ToString().Should()
+				.Contain(
+					$"type '{typeof(BarClass)}' should have a method with return type {nameof(DummyFooClass)}");
+		}
+
+		[Fact]
+		public void OrReturnType_WithGenericParameter_ShouldReturnBothTypes()
+		{
+			ITestResult result = Expect.That.Types
+				.WhichAre(typeof(BarClass), typeof(FooClass))
+				.Should(Have.Method.WithReturnType<DummyFooClass>().OrReturnType<DummyBarClass>())
+				.Check.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		[Fact]
+		public void OrReturnType_WithType_ShouldReturnBothTypes()
+		{
+			ITestResult result = Expect.That.Types
+				.WhichAre(typeof(BarClass), typeof(FooClass))
+				.Should(Have.Method.WithReturnType(typeof(DummyFooClass))
+					.OrReturnType(typeof(DummyBarClass)))
+				.Check.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		private class BarClass
+		{
+			public DummyBarClass BarMethod(int value)
+				=> new(value);
+		}
+
+		private class FooClass
+		{
+			public DummyFooClass FooMethod(int value)
+				=> new(value);
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/PropertyFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/PropertyFilterExtensionsTests.NameMatch.cs
@@ -5,7 +5,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 
 public sealed partial class PropertyFilterExtensionsTests
 {
-	public sealed class WithNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTProperty", false)]
@@ -16,12 +16,12 @@ public sealed partial class PropertyFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*y", true)]
 		[InlineData("*property", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Property.WithName(pattern))
+				.Which(Have.Property.WhichNameMatches(pattern))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();
@@ -37,12 +37,12 @@ public sealed partial class PropertyFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*y", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
-				.Which(Have.Property.WithName(pattern, true))
+				.Which(Have.Property.WhichNameMatches(pattern, true))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/TypeFilterExtensionsTests.NameMatch.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/TypeFilterExtensionsTests.NameMatch.cs
@@ -6,7 +6,7 @@ namespace Testably.Architecture.Rules.Tests.Filters;
 
 public sealed partial class TypeFilterExtensionsTests
 {
-	public sealed class MatchNameTests
+	public sealed class NameMatchTests
 	{
 		[Theory]
 		[InlineData("TESTClass", false)]
@@ -17,13 +17,13 @@ public sealed partial class TypeFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*s", true)]
 		[InlineData("*class", false)]
-		public void WhichDoNotMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameDoesNotMatch_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITypeFilter source = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And;
 
-			ITypeFilterResult sut = source.WhichDoNotMatchName(pattern);
+			ITypeFilterResult sut = source.WhichNameDoesNotMatch(pattern);
 
 			ITestResult result = sut
 				.ShouldAlwaysFail()
@@ -42,13 +42,13 @@ public sealed partial class TypeFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*s", true)]
-		public void WhichDoNotMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameDoesNotMatch_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITypeFilter source = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And;
 
-			ITypeFilterResult sut = source.WhichDoNotMatchName(pattern, true);
+			ITypeFilterResult sut = source.WhichNameDoesNotMatch(pattern, true);
 
 			ITestResult result = sut
 				.ShouldAlwaysFail()
@@ -68,13 +68,13 @@ public sealed partial class TypeFilterExtensionsTests
 		[InlineData("test*", false)]
 		[InlineData("T*s", true)]
 		[InlineData("*class", false)]
-		public void WhichMatchName_CaseSensitive_ShouldReturnExpectedValue(
+		public void WhichNameMatches_CaseSensitive_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITypeFilter source = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And;
 
-			ITypeFilterResult sut = source.WhichMatchName(pattern);
+			ITypeFilterResult sut = source.WhichNameMatches(pattern);
 
 			ITestResult result = sut
 				.ShouldAlwaysFail()
@@ -93,13 +93,13 @@ public sealed partial class TypeFilterExtensionsTests
 		[InlineData("test*", true)]
 		[InlineData("test???", false)]
 		[InlineData("t*s", true)]
-		public void WhichMatchName_WithIgnoreCase_ShouldReturnExpectedValue(
+		public void WhichNameMatches_WithIgnoreCase_ShouldReturnExpectedValue(
 			string pattern, bool expectMatch)
 		{
 			ITypeFilter source = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And;
 
-			ITypeFilterResult sut = source.WhichMatchName(pattern, true);
+			ITypeFilterResult sut = source.WhichNameMatches(pattern, true);
 
 			ITestResult result = sut
 				.ShouldAlwaysFail()

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.MatchName.cs
@@ -1,0 +1,128 @@
+﻿using FluentAssertions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnEventExtensionsTests
+{
+	public sealed class MatchNameTests
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldMatchName("DUMMYfooEVENT1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(!ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooEvent1")]
+		[InlineData("DummyFooEvent1")]
+		public void ShouldMatchName_MatchingPattern_ShouldNotBeViolated(string matchingPattern)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooEvent1")]
+		[InlineData("dummyfooevent1")]
+		public void ShouldMatchName_NotMatchingPattern_ShouldNotBeSatisfied(
+			string notMatchingPattern)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<EventTestError>()
+				.Which.Event.Should().BeSameAs(@event);
+			result.Errors[0].Should().BeOfType<EventTestError>()
+				.Which.ToString().Should().Contain(@event.Name).And.Contain($"'{notMatchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldNotMatchName("DUMMYfooEVENT1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooEvent1")]
+		[InlineData("DummyFooEvent1")]
+		public void ShouldNotMatchName_MatchingPattern_ShouldNotBeSatisfied(string matchingPattern)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldNotMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<EventTestError>()
+				.Which.Event.Should().BeSameAs(@event);
+			result.Errors[0].Should().BeOfType<EventTestError>()
+				.Which.ToString().Should().Contain(@event.Name).And.Contain($"'{matchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooEvent1")]
+		[InlineData("dummyfooevent1")]
+		public void ShouldNotMatchName_NotMatchingPattern_ShouldNotBeViolated(
+			string notMatchingPattern)
+		{
+			EventInfo @event =
+				typeof(DummyFooClass).GetEvent(nameof(DummyFooClass.DummyFooEvent1))!;
+			IRule rule = Expect.That.Events
+				.WhichAre(@event)
+				.ShouldNotMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.MatchName.cs
@@ -1,0 +1,129 @@
+﻿using FluentAssertions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed class RequirementOnFieldExtensionsTests
+{
+	public sealed class MatchNameTests
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldMatchName("DUMMYfooFIELD1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(!ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooField1")]
+		[InlineData("DummyFooField1")]
+		public void ShouldMatchName_MatchingPattern_ShouldNotBeViolated(string matchingPattern)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooField1")]
+		[InlineData("dummyfoofield1")]
+		public void ShouldMatchName_NotMatchingPattern_ShouldNotBeSatisfied(
+			string notMatchingPattern)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<FieldTestError>()
+				.Which.Field.Should().BeSameAs(field);
+			result.Errors[0].Should().BeOfType<FieldTestError>()
+				.Which.ToString().Should().Contain(field.Name).And
+				.Contain($"'{notMatchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldNotMatchName("DUMMYfooFIELD1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooField1")]
+		[InlineData("DummyFooField1")]
+		public void ShouldNotMatchName_MatchingPattern_ShouldNotBeSatisfied(string matchingPattern)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldNotMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<FieldTestError>()
+				.Which.Field.Should().BeSameAs(field);
+			result.Errors[0].Should().BeOfType<FieldTestError>()
+				.Which.ToString().Should().Contain(field.Name).And.Contain($"'{matchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooField1")]
+		[InlineData("dummyfoofield1")]
+		public void ShouldNotMatchName_NotMatchingPattern_ShouldNotBeViolated(
+			string notMatchingPattern)
+		{
+			FieldInfo field =
+				typeof(DummyFooClass).GetField(nameof(DummyFooClass.DummyFooField1))!;
+			IRule rule = Expect.That.Fields
+				.WhichAre(field)
+				.ShouldNotMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.HaveParameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.HaveParameter.cs
@@ -12,6 +12,59 @@ public sealed partial class RequirementOnMethodExtensionsTests
 	public sealed class HaveParameterTests
 	{
 		[Theory]
+		[InlineData(nameof(TestClass.TestMethodWithoutParameters), true)]
+		[InlineData(nameof(TestClass.TestMethodWithStringParameter), true)]
+		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), false)]
+		public void ShouldHave_WithAnyIntParameter_ShouldResultInExpectViolation(
+			string methodName, bool expectViolation)
+		{
+			MethodInfo method = typeof(TestClass)
+				.GetMethod(methodName)!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldHave(Parameters.Any.OfType<int>());
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{method.Name}'").And
+					.Contain($"should have a parameter which is of type {nameof(Int32)}");
+			}
+		}
+
+		[Theory]
+		[InlineData(nameof(TestClass.TestMethodWithoutParameters), true)]
+		[InlineData(nameof(TestClass.TestMethodWithStringParameter), true)]
+		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), false)]
+		public void ShouldHave_WithOrderedStringAndInt_ShouldResultInExpectViolation(
+			string methodName, bool expectViolation)
+		{
+			MethodInfo method = typeof(TestClass)
+				.GetMethod(methodName)!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldHave(Parameters.InOrder
+					.OfType<string>().Then()
+					.OfType<int>());
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{method.Name}'").And
+					.Contain(
+						$"should have parameters whose 1st parameter is of type {nameof(String)} and 2nd parameter is of type {nameof(Int32)}");
+			}
+		}
+
+		[Theory]
 		[InlineData(nameof(TestClass.TestMethodWithoutParameters), false)]
 		[InlineData(nameof(TestClass.TestMethodWithStringParameter), true)]
 		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), true)]
@@ -88,59 +141,7 @@ public sealed partial class RequirementOnMethodExtensionsTests
 			}
 		}
 
-		[Theory]
-		[InlineData(nameof(TestClass.TestMethodWithoutParameters), true)]
-		[InlineData(nameof(TestClass.TestMethodWithStringParameter), true)]
-		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), false)]
-		public void ShouldHave_WithAnyIntParameter_ShouldResultInExpectViolation(
-			string methodName, bool expectViolation)
-		{
-			MethodInfo method = typeof(TestClass)
-				.GetMethod(methodName)!;
-			IRule rule = Expect.That.Methods
-				.WhichAre(method)
-				.ShouldHave(Parameters.Any.OfType<int>());
-
-			ITestResult result = rule.Check
-				.InAllLoadedAssemblies();
-
-			result.ShouldBeViolatedIf(expectViolation);
-			if (expectViolation)
-			{
-				result.Errors[0].ToString().Should()
-					.Contain($"'{method.Name}'").And
-					.Contain($"should have a parameter which is of type {nameof(Int32)}");
-			}
-		}
-
-		[Theory]
-		[InlineData(nameof(TestClass.TestMethodWithoutParameters), true)]
-		[InlineData(nameof(TestClass.TestMethodWithStringParameter), true)]
-		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), false)]
-		public void ShouldHave_WithOrderedStringAndInt_ShouldResultInExpectViolation(
-			string methodName, bool expectViolation)
-		{
-			MethodInfo method = typeof(TestClass)
-				.GetMethod(methodName)!;
-			IRule rule = Expect.That.Methods
-				.WhichAre(method)
-				.ShouldHave(Parameters.InOrder
-					.OfType<string>().Then()
-					.OfType<int>());
-
-			ITestResult result = rule.Check
-				.InAllLoadedAssemblies();
-
-			result.ShouldBeViolatedIf(expectViolation);
-			if (expectViolation)
-			{
-				result.Errors[0].ToString().Should()
-					.Contain($"'{method.Name}'").And
-					.Contain($"should have parameters whose 1st parameter is of type {nameof(String)} and 2nd parameter is of type {nameof(Int32)}");
-			}
-		}
-
-#pragma warning disable CA1822
+		#pragma warning disable CA1822
 		private class TestClass
 		{
 			public void TestMethodWithoutParameters()

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.MatchName.cs
@@ -1,0 +1,130 @@
+﻿using FluentAssertions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnMethodExtensionsTests
+{
+	public sealed class MatchNameTests
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldMatchName("DUMMYfooMETHOD1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(!ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooMethod1")]
+		[InlineData("DummyFooMethod1")]
+		public void ShouldMatchName_MatchingPattern_ShouldNotBeViolated(string matchingPattern)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooMethod1")]
+		[InlineData("dummyfoomethod1")]
+		public void ShouldMatchName_NotMatchingPattern_ShouldNotBeSatisfied(
+			string notMatchingPattern)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<MethodTestError>()
+				.Which.Method.Should().BeSameAs(method);
+			result.Errors[0].Should().BeOfType<MethodTestError>()
+				.Which.ToString().Should()
+				.Contain(method.Name).And.Contain($"'{notMatchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldNotMatchName("DUMMYfooMETHOD1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooMethod1")]
+		[InlineData("DummyFooMethod1")]
+		public void ShouldNotMatchName_MatchingPattern_ShouldNotBeSatisfied(string matchingPattern)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldNotMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<MethodTestError>()
+				.Which.Method.Should().BeSameAs(method);
+			result.Errors[0].Should().BeOfType<MethodTestError>()
+				.Which.ToString().Should()
+				.Contain(method.Name).And.Contain($"'{matchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooMethod1")]
+		[InlineData("dummyfoomethod1")]
+		public void ShouldNotMatchName_NotMatchingPattern_ShouldNotBeViolated(
+			string notMatchingPattern)
+		{
+			MethodInfo method =
+				typeof(DummyFooClass).GetMethod(nameof(DummyFooClass.DummyFooMethod1))!;
+			IRule rule = Expect.That.Methods
+				.WhichAre(method)
+				.ShouldNotMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.MatchName.cs
@@ -1,0 +1,130 @@
+﻿using FluentAssertions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed class RequirementOnPropertyExtensionsTests
+{
+	public sealed class MatchNameTests
+	{
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldMatchName("DUMMYfooPROPERTY1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(!ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooProperty1")]
+		[InlineData("DummyFooProperty1")]
+		public void ShouldMatchName_MatchingPattern_ShouldNotBeViolated(string matchingPattern)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooProperty1")]
+		[InlineData("dummyfooproperty1")]
+		public void ShouldMatchName_NotMatchingPattern_ShouldNotBeSatisfied(
+			string notMatchingPattern)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<PropertyTestError>()
+				.Which.Property.Should().BeSameAs(property);
+			result.Errors[0].Should().BeOfType<PropertyTestError>()
+				.Which.ToString().Should().Contain(property.Name).And
+				.Contain($"'{notMatchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void ShouldNotMatchName_IgnoreCase_ShouldConsiderParameter(bool ignoreCase)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldNotMatchName("DUMMYfooPROPERTY1", ignoreCase);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(ignoreCase);
+		}
+
+		[Theory]
+		[InlineData("*")]
+		[InlineData("?????FooProperty1")]
+		[InlineData("DummyFooProperty1")]
+		public void ShouldNotMatchName_MatchingPattern_ShouldNotBeSatisfied(string matchingPattern)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldNotMatchName(matchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolated();
+			result.Errors[0].Should().BeOfType<PropertyTestError>()
+				.Which.Property.Should().BeSameAs(property);
+			result.Errors[0].Should().BeOfType<PropertyTestError>()
+				.Which.ToString().Should().Contain(property.Name).And
+				.Contain($"'{matchingPattern}'");
+		}
+
+		[Theory]
+		[InlineData("*Foo")]
+		[InlineData("??FooProperty1")]
+		[InlineData("dummyfooproperty1")]
+		public void ShouldNotMatchName_NotMatchingPattern_ShouldNotBeViolated(
+			string notMatchingPattern)
+		{
+			PropertyInfo property =
+				typeof(DummyFooClass).GetProperty(nameof(DummyFooClass.DummyFooProperty1))!;
+			IRule rule = Expect.That.Properties
+				.WhichAre(property)
+				.ShouldNotMatchName(notMatchingPattern);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldNotBeViolated();
+		}
+	}
+}


### PR DESCRIPTION
Add a filter `.WithReturnType` for methods and `NameMatches` requirements for events, fields, methods and properties.

This supports an additional example test:
```csharp
	/// <summary>
	///     Methods that return Task should have Async suffix
	/// </summary>
	[Fact]
	public void AsyncMethodsShouldHaveAsyncSuffix()
	{
		IRule rule = Expect.That.Methods
			.WithReturnType<Task>().OrReturnType(typeof(Task<>))
			.ShouldMatchName("*Async")
			.AllowEmpty();

		rule.Check
			.InTestAssembly()
			.ThrowIfViolated();
	}
```
