### PR TITLE
feat: add parameters for constructors

### DIFF
--- a/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
@@ -158,8 +158,7 @@ public static class TypeExtensions
 			return false;
 		}
 
-		if (type.IsGenericType &&
-		    type.GetGenericTypeDefinition() == other.GetGenericTypeDefinition())
+		if (type.IsGenericType)
 		{
 			return AreGenericTypesCompatible(type, other);
 		}
@@ -209,14 +208,20 @@ public static class TypeExtensions
 	/// <returns></returns>
 	private static bool AreGenericTypesCompatible(Type type, Type other)
 	{
+		if (type.GetGenericTypeDefinition() != other.GetGenericTypeDefinition())
+		{
+			return false;
+		}
+
 		if (!type.IsGenericTypeDefinition && !other.IsGenericTypeDefinition)
 		{
 			Type[]? typeArguments = type.GetGenericArguments();
 			Type[]? otherArguments = other.GetGenericArguments();
+			// `type` and `other` have the same number of arguments,
+			// because otherwise the GetGenericTypeDefinition() check would be different for both!
 			for (int i = 0; i < typeArguments.Length; i++)
 			{
-				if (otherArguments.Length >= i &&
-				    !typeArguments[i].IsEqualTo(otherArguments[i]))
+				if (!typeArguments[i].IsEqualTo(otherArguments[i]))
 				{
 					return false;
 				}

--- a/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Extensions/TypeExtensions.cs
@@ -158,26 +158,10 @@ public static class TypeExtensions
 			return false;
 		}
 
-		if (type.IsGenericType)
+		if (type.IsGenericType &&
+		    type.GetGenericTypeDefinition() == other.GetGenericTypeDefinition())
 		{
-			if (type.GetGenericTypeDefinition() == other.GetGenericTypeDefinition())
-			{
-				if (!type.IsGenericTypeDefinition && !other.IsGenericTypeDefinition)
-				{
-					Type[]? typeArguments = type.GetGenericArguments();
-					Type[]? otherArguments = other.GetGenericArguments();
-					for (int i = 0; i < typeArguments.Length; i++)
-					{
-						if (otherArguments.Length >= i &&
-						    !typeArguments[i].IsEqualTo(otherArguments[i]))
-						{
-							return false;
-						}
-					}
-				}
-
-				return true;
-			}
+			return AreGenericTypesCompatible(type, other);
 		}
 
 		return type == other;
@@ -214,4 +198,31 @@ public static class TypeExtensions
 	/// <remarks>https://stackoverflow.com/a/1175901</remarks>
 	public static bool IsStatic(this Type type)
 		=> type.IsAbstract && type.IsSealed && !type.IsInterface;
+
+	/// <summary>
+	///     Check if the generic types are compatible.<br />
+	///     Generic types are considered compatible, if either one or both are open generics or the generic argument types
+	///     themselves are equal.
+	/// </summary>
+	/// <param name="type"></param>
+	/// <param name="other"></param>
+	/// <returns></returns>
+	private static bool AreGenericTypesCompatible(Type type, Type other)
+	{
+		if (!type.IsGenericTypeDefinition && !other.IsGenericTypeDefinition)
+		{
+			Type[]? typeArguments = type.GetGenericArguments();
+			Type[]? otherArguments = other.GetGenericArguments();
+			for (int i = 0; i < typeArguments.Length; i++)
+			{
+				if (otherArguments.Length >= i &&
+				    !typeArguments[i].IsEqualTo(otherArguments[i]))
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
 }

--- a/Source/Testably.Architecture.Rules/Filters/ConstructorFilterExtensions.Parameters.cs
+++ b/Source/Testably.Architecture.Rules/Filters/ConstructorFilterExtensions.Parameters.cs
@@ -42,4 +42,16 @@ public static partial class ConstructorFilterExtensions
 			constructor => constructor.GetParameters().Length == 0,
 			"without parameter");
 	}
+
+	/// <summary>
+	///     Filters for <see cref="ConstructorInfo" />s with (at least) <paramref name="minimumCount" /> parameters.
+	/// </summary>
+	public static IConstructorFilterResult WithParameters(
+		this IConstructorFilter @this,
+		int minimumCount = 1)
+	{
+		return @this.Which(
+			method => method.GetParameters().Length >= minimumCount,
+			$"with at least {minimumCount} {(minimumCount > 1 ? "parameters" : "parameter")}");
+	}
 }

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnConstructorExtensions.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnConstructorExtensions.cs
@@ -7,7 +7,7 @@ namespace Testably.Architecture.Rules;
 /// <summary>
 ///     Extension constructors for <see cref="IRequirement{ConstructorInfo}" />.
 /// </summary>
-public static class RequirementOnConstructorExtensions
+public static partial class RequirementOnConstructorExtensions
 {
 	/// <summary>
 	///     The <see cref="ConstructorInfo" /> should satisfy the given <paramref name="condition" />.

--- a/Source/Testably.Architecture.Rules/Requirements/RequirementOnConstructorExtensionsHaveParameter.cs
+++ b/Source/Testably.Architecture.Rules/Requirements/RequirementOnConstructorExtensionsHaveParameter.cs
@@ -1,0 +1,57 @@
+﻿using System.Reflection;
+
+namespace Testably.Architecture.Rules;
+
+public static partial class RequirementOnConstructorExtensions
+{
+	/// <summary>
+	///     The parameters of the <see cref="ConstructorInfo" /> should satisfy the given <paramref name="parameterFilter" />.
+	/// </summary>
+	public static IRequirementResult<ConstructorInfo> ShouldHave(
+		this IRequirement<ConstructorInfo> @this,
+		IUnorderedParameterFilterResult parameterFilter)
+	{
+		return @this.ShouldSatisfy(Requirement.ForConstructor(
+			m => parameterFilter.Apply(m.GetParameters()),
+			constructor => new ConstructorTestError(constructor,
+				$"The constructor '{constructor.Name}' should have a parameter which {parameterFilter}.")));
+	}
+
+	/// <summary>
+	///     The parameters of the <see cref="ConstructorInfo" /> should satisfy the given <paramref name="parameterFilter" />.
+	/// </summary>
+	public static IRequirementResult<ConstructorInfo> ShouldHave(
+		this IRequirement<ConstructorInfo> @this,
+		IOrderedParameterFilterResult parameterFilter)
+	{
+		return @this.ShouldSatisfy(Requirement.ForConstructor(
+			m => parameterFilter.Apply(m.GetParameters()),
+			constructor => new ConstructorTestError(constructor,
+				$"The constructor '{constructor.Name}' should have parameters whose {parameterFilter.FriendlyName()}.")));
+	}
+
+	/// <summary>
+	///     The <see cref="ConstructorInfo" /> should have no parameters.
+	/// </summary>
+	public static IRequirementResult<ConstructorInfo> ShouldHaveNoParameters(
+		this IRequirement<ConstructorInfo> @this)
+	{
+		return @this.ShouldSatisfy(Requirement.ForConstructor(
+			constructor => constructor.GetParameters().Length == 0,
+			constructor => new ConstructorTestError(constructor,
+				$"The constructor '{constructor.Name}' should have no parameters.")));
+	}
+
+	/// <summary>
+	///     The <see cref="ConstructorInfo" /> should have (at least) <paramref name="minimumCount" /> parameters.
+	/// </summary>
+	public static IRequirementResult<ConstructorInfo> ShouldHaveParameters(
+		this IRequirement<ConstructorInfo> @this,
+		int minimumCount = 1)
+	{
+		return @this.ShouldSatisfy(Requirement.ForConstructor(
+			constructor => constructor.GetParameters().Length >= minimumCount,
+			constructor => new ConstructorTestError(constructor,
+				$"The constructor '{constructor.Name}' should have at least {minimumCount} {(minimumCount > 1 ? "parameters" : "parameter")}.")));
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Extensions/TypeExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Extensions/TypeExtensionsTests.cs
@@ -84,6 +84,26 @@ public sealed class TypeExtensionsTests
 	}
 
 	[Fact]
+	public void IsEqualTo_DifferentNumberOfClosedGenericParameters_ShouldReturnFalse()
+	{
+		Type sut = typeof(Tuple<int, string>);
+
+		bool result = sut.IsEqualTo(typeof(Tuple<int, string, int>));
+
+		result.Should().BeFalse();
+	}
+
+	[Fact]
+	public void IsEqualTo_DifferentNumberOfOpenGenericParameters_ShouldReturnFalse()
+	{
+		Type sut = typeof(Tuple<,>);
+
+		bool result = sut.IsEqualTo(typeof(Tuple<,,>));
+
+		result.Should().BeFalse();
+	}
+
+	[Fact]
 	public void IsEqualTo_SameGenericType_OtherOpen_ShouldReturnTrue()
 	{
 		Type sut = typeof(Task<>);

--- a/Tests/Testably.Architecture.Rules.Tests/FilterTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/FilterTests.cs
@@ -457,7 +457,7 @@ public sealed class FilterTests
 		IRequirementResult<PropertyInfo> rule = sut.Properties.ShouldSatisfy(_ => false);
 
 		ITestResult result = rule.Check.InAllLoadedAssemblies();
-		result.Errors.Length.Should().Be(6);
+		result.Errors.Length.Should().Be(4);
 		result.Errors.Should().Contain(e
 			=> ((PropertyTestError)e).Property.DeclaringType == typeof(DummyFooClass));
 		result.Errors.Should().Contain(e

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
@@ -82,15 +82,51 @@ public sealed partial class ConstructorFilterExtensionsTests
 			sut.ToString().Should().Contain("without parameter");
 		}
 
-		[AttributeUsage(AttributeTargets.Constructor)]
-		public class ParameterCountAttribute : Attribute
+		[Theory]
+		[InlineData(0, false)]
+		[InlineData(1, true)]
+		[InlineData(2, true)]
+		public void WithParameter_ShouldBeFoundWhenConstructorHasAtLeastOneParameter(
+			int parameterCount, bool expectFound)
 		{
-			public int Count { get; }
+			ITypeFilter source = Expect.That.Types
+				.WhichAre(typeof(TestClass)).And;
 
-			public ParameterCountAttribute(int count)
-			{
-				Count = count;
-			}
+			ITypeFilterResult sut = source.Which(Have.Constructor
+				.WithAttribute<ParameterCountAttribute>(p => p.Count == parameterCount).And
+				.WithParameters());
+
+			ITestResult result = sut.ShouldAlwaysFail()
+				.AllowEmpty()
+				.Check.InAllLoadedAssemblies();
+			result.ShouldBeViolatedIf(expectFound);
+			sut.ToString().Should()
+				.Contain("with at least 1 parameter").And
+				.NotContain("parameters");
+		}
+
+		[Theory]
+		[InlineData(0, 2, false)]
+		[InlineData(1, 2, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(2, 3, false)]
+		public void
+			WithParameter_WithMinimumCount_ShouldBeFoundWhenConstructorHasAtLeastTheRequiredParameters(
+				int parameterCount, int minimumCount, bool expectFound)
+		{
+			ITypeFilter source = Expect.That.Types
+				.WhichAre(typeof(TestClass)).And;
+
+			ITypeFilterResult sut = source.Which(Have.Constructor
+				.WithAttribute<ParameterCountAttribute>(p => p.Count == parameterCount).And
+				.WithParameters(minimumCount));
+
+			ITestResult result = sut.ShouldAlwaysFail()
+				.AllowEmpty()
+				.Check.InAllLoadedAssemblies();
+			result.ShouldBeViolatedIf(expectFound);
+			sut.ToString().Should()
+				.Contain($"with at least {minimumCount} parameters");
 		}
 
 		private class TestClass
@@ -106,7 +142,7 @@ public sealed partial class ConstructorFilterExtensionsTests
 			}
 
 			[ParameterCount(2)]
-			public TestClass(int value1, string value2)
+			public TestClass(string value1, int value2)
 			{
 			}
 		}

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using System;
 using Testably.Architecture.Rules.Tests.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
@@ -95,7 +95,7 @@ public sealed partial class MethodFilterExtensionsTests
 		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), 2, true)]
 		[InlineData(nameof(TestClass.TestMethodWithStringAndIntParameter), 3, false)]
 		public void
-			WithParameter_WithMinimumCount_ShouldBeFoundWhenMethodHaveAtLeastTheRequiredParameters(
+			WithParameter_WithMinimumCount_ShouldBeFoundWhenMethodHasAtLeastTheRequiredParameters(
 				string methodName, int minimumCount, bool expectFound)
 		{
 			ITypeFilter source = Expect.That.Types
@@ -121,7 +121,7 @@ public sealed partial class MethodFilterExtensionsTests
 				// Do nothing
 			}
 
-			public void TestMethodWithStringAndIntParameter(int value1, string value2)
+			public void TestMethodWithStringAndIntParameter(string value1, int value2)
 			{
 				// Do nothing
 			}

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
@@ -46,6 +46,7 @@ public sealed partial class MethodFilterExtensionsTests
 			result.ShouldNotBeViolated();
 		}
 
+		#pragma warning disable CA1822
 		private class BarClass
 		{
 			public DummyBarClass BarMethod(int value)
@@ -57,5 +58,6 @@ public sealed partial class MethodFilterExtensionsTests
 			public DummyFooClass FooMethod(int value)
 				=> new(value);
 		}
+		#pragma warning restore CA1822
 	}
 }

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.WithReturnType.cs
@@ -23,6 +23,21 @@ public sealed partial class MethodFilterExtensionsTests
 					$"type '{typeof(BarClass)}' should have a method with return type {nameof(DummyFooClass)}");
 		}
 
+		[Theory]
+		[InlineData(true, false)]
+		[InlineData(false, true)]
+		public void OrReturnType_WithDerivedType_ShouldConsiderAllowDerivedTypeParameter(
+			bool allowDerivedType,
+			bool expectViolation)
+		{
+			ITestResult result = Expect.That.Types
+				.WhichAre(typeof(FooClass))
+				.Should(Have.Method.WithReturnType<DummyFooBase>(allowDerivedType))
+				.Check.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+		}
+
 		[Fact]
 		public void OrReturnType_WithGenericParameter_ShouldReturnBothTypes()
 		{

--- a/Tests/Testably.Architecture.Rules.Tests/Internal/TypeRuleTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Internal/TypeRuleTests.cs
@@ -353,7 +353,7 @@ public sealed class TypeRuleTests
 		ITestResult result = rule.Check
 			.InAllLoadedAssemblies();
 
-		result.Errors.Length.Should().Be(3);
+		result.Errors.Length.Should().Be(2);
 		result.Errors.Should().Contain(e => e.ToString().Contains(expectedPropertyName1));
 		result.Errors.Should().NotContain(e => e.ToString().Contains(expectedPropertyName2));
 	}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.HaveParameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.HaveParameter.cs
@@ -1,0 +1,164 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+public sealed partial class RequirementOnConstructorExtensionsTests
+{
+	public sealed class HaveParameterTests
+	{
+		[Theory]
+		[InlineData(0, true)]
+		[InlineData(1, true)]
+		[InlineData(2, false)]
+		public void ShouldHave_WithAnyIntParameter_ShouldResultInExpectViolation(
+			int parameterCount, bool expectViolation)
+		{
+			ConstructorInfo constructor = typeof(TestClass).GetConstructors()
+				.First(p => p.GetParameters().Length == parameterCount);
+			IRule rule = Expect.That.Constructors
+				.WhichAre(constructor)
+				.ShouldHave(Parameters.Any.OfType<int>());
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{constructor.Name}'").And
+					.Contain($"should have a parameter which is of type {nameof(Int32)}");
+			}
+		}
+
+		[Theory]
+		[InlineData(0, true)]
+		[InlineData(1, true)]
+		[InlineData(2, false)]
+		public void ShouldHave_WithOrderedStringAndInt_ShouldResultInExpectViolation(
+			int parameterCount, bool expectViolation)
+		{
+			ConstructorInfo constructor = typeof(TestClass).GetConstructors()
+				.First(p => p.GetParameters().Length == parameterCount);
+			IRule rule = Expect.That.Constructors
+				.WhichAre(constructor)
+				.ShouldHave(Parameters.InOrder
+					.OfType<string>().Then()
+					.OfType<int>());
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{constructor.Name}'").And
+					.Contain(
+						$"should have parameters whose 1st parameter is of type {nameof(String)} and 2nd parameter is of type {nameof(Int32)}");
+			}
+		}
+
+		[Theory]
+		[InlineData(0, false)]
+		[InlineData(1, true)]
+		[InlineData(2, true)]
+		public void ShouldHaveNoParameters_WithConstructorName_ShouldResultInExpectViolation(
+			int parameterCount, bool expectViolation)
+		{
+			ConstructorInfo constructor = typeof(TestClass).GetConstructors()
+				.First(p => p.GetParameters().Length == parameterCount);
+			IRule rule = Expect.That.Constructors
+				.WhichAre(constructor)
+				.ShouldHaveNoParameters();
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{constructor.Name}'").And
+					.Contain("should have no parameters");
+			}
+		}
+
+		[Theory]
+		[InlineData(0, true)]
+		[InlineData(1, false)]
+		[InlineData(2, false)]
+		public void ShouldHaveParameters_WithConstructorName_ShouldResultInExpectViolation(
+			int parameterCount, bool expectViolation)
+		{
+			ConstructorInfo constructor = typeof(TestClass).GetConstructors()
+				.First(p => p.GetParameters().Length == parameterCount);
+			IRule rule = Expect.That.Constructors
+				.WhichAre(constructor)
+				.ShouldHaveParameters();
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{constructor.Name}'").And
+					.Contain("should have at least 1 parameter").And
+					.NotContain("parameters");
+			}
+		}
+
+		[Theory]
+		[InlineData(0, 2, true)]
+		[InlineData(1, 2, true)]
+		[InlineData(2, 2, false)]
+		[InlineData(2, 3, true)]
+		public void ShouldHaveParameters_WithMinimumCount_ShouldResultInExpectViolation(
+			int parameterCount, int minimumCount, bool expectViolation)
+		{
+			ConstructorInfo constructor = typeof(TestClass).GetConstructors()
+				.First(p => p.GetParameters().Length == parameterCount);
+			IRule rule = Expect.That.Constructors
+				.WhichAre(constructor)
+				.ShouldHaveParameters(minimumCount);
+
+			ITestResult result = rule.Check
+				.InAllLoadedAssemblies();
+
+			result.ShouldBeViolatedIf(expectViolation);
+			if (expectViolation)
+			{
+				result.Errors[0].ToString().Should()
+					.Contain($"'{constructor.Name}'").And
+					.Contain($"should have at least {minimumCount} parameters");
+			}
+		}
+
+		private class TestClass
+		{
+			[ParameterCount(0)]
+			public TestClass()
+			{
+			}
+
+			[ParameterCount(1)]
+			public TestClass(string value1)
+			{
+			}
+
+			[ParameterCount(2)]
+			public TestClass(string value1, int value2)
+			{
+			}
+		}
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnConstructorExtensionsTests
+{
+	[Fact]
+	public void ShouldSatisfy_Expression_ShouldContainExpressionString()
+	{
+		ConstructorInfo constructor = typeof(DummyFooClass).GetConstructors().First();
+		Expression<Func<ConstructorInfo, bool>> expression = _ => false;
+		IRule rule = Expect.That.Constructors
+			.WhichAre(constructor)
+			.ShouldSatisfy(expression);
+
+		ITestResult result = rule.Check
+			.InAllLoadedAssemblies();
+
+		result.ShouldBeViolated();
+		result.Errors[0].Should().BeOfType<ConstructorTestError>()
+			.Which.ToString().Should().Contain(expression.ToString());
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.MatchName.cs
@@ -64,7 +64,8 @@ public sealed partial class RequirementOnEventExtensionsTests
 			result.Errors[0].Should().BeOfType<EventTestError>()
 				.Which.Event.Should().BeSameAs(@event);
 			result.Errors[0].Should().BeOfType<EventTestError>()
-				.Which.ToString().Should().Contain(@event.Name).And.Contain($"'{notMatchingPattern}'");
+				.Which.ToString().Should().Contain(@event.Name).And
+				.Contain($"'{notMatchingPattern}'");
 		}
 
 		[Theory]

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnEventExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnEventExtensionsTests
+{
+	[Fact]
+	public void ShouldSatisfy_Expression_ShouldContainExpressionString()
+	{
+		EventInfo @event = typeof(DummyFooClass).GetEvents().First();
+		Expression<Func<EventInfo, bool>> expression = _ => false;
+		IRule rule = Expect.That.Events
+			.WhichAre(@event)
+			.ShouldSatisfy(expression);
+
+		ITestResult result = rule.Check
+			.InAllLoadedAssemblies();
+
+		result.ShouldBeViolated();
+		result.Errors[0].Should().BeOfType<EventTestError>()
+			.Which.ToString().Should().Contain(expression.ToString());
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.MatchName.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Testably.Architecture.Rules.Tests.Requirements;
 
-public sealed class RequirementOnFieldExtensionsTests
+public sealed partial class RequirementOnFieldExtensionsTests
 {
 	public sealed class MatchNameTests
 	{

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnFieldExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnFieldExtensionsTests
+{
+	[Fact]
+	public void ShouldSatisfy_Expression_ShouldContainExpressionString()
+	{
+		FieldInfo field = typeof(DummyFooClass).GetFields().First();
+		Expression<Func<FieldInfo, bool>> expression = _ => false;
+		IRule rule = Expect.That.Fields
+			.WhichAre(field)
+			.ShouldSatisfy(expression);
+
+		ITestResult result = rule.Check
+			.InAllLoadedAssemblies();
+
+		result.ShouldBeViolated();
+		result.Errors[0].Should().BeOfType<FieldTestError>()
+			.Which.ToString().Should().Contain(expression.ToString());
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.MatchName.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.MatchName.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Testably.Architecture.Rules.Tests.Requirements;
 
-public sealed class RequirementOnPropertyExtensionsTests
+public sealed partial class RequirementOnPropertyExtensionsTests
 {
 	public sealed class MatchNameTests
 	{

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnPropertyExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Testably.Architecture.Rules.Tests.TestHelpers;
+using Xunit;
+
+namespace Testably.Architecture.Rules.Tests.Requirements;
+
+public sealed partial class RequirementOnPropertyExtensionsTests
+{
+	[Fact]
+	public void ShouldSatisfy_Expression_ShouldContainExpressionString()
+	{
+		PropertyInfo property = typeof(DummyFooClass).GetProperties().First();
+		Expression<Func<PropertyInfo, bool>> expression = _ => false;
+		IRule rule = Expect.That.Properties
+			.WhichAre(property)
+			.ShouldSatisfy(expression);
+
+		ITestResult result = rule.Check
+			.InAllLoadedAssemblies();
+
+		result.ShouldBeViolated();
+		result.Errors[0].Should().BeOfType<PropertyTestError>()
+			.Which.ToString().Should().Contain(expression.ToString());
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyBarBase.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyBarBase.cs
@@ -1,0 +1,11 @@
+﻿namespace Testably.Architecture.Rules.Tests.TestHelpers;
+
+public class DummyBarBase
+{
+	public int Value { get; }
+	public DummyBarBase(int value)
+	{
+		Value = value;
+	}
+
+}

--- a/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyBarClass.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyBarClass.cs
@@ -4,11 +4,10 @@
 // ReSharper disable UnusedMember.Local
 // ReSharper disable UnusedParameter.Local
 [DummyBar]
-internal class DummyBarClass
+internal class DummyBarClass : DummyBarBase
 {
 	public int? DummyBarProperty1 { get; set; }
 	public int? DummyBarProperty2 { get; set; }
-	public int Value { get; }
 
 	public delegate void DummyBar();
 
@@ -29,13 +28,13 @@ internal class DummyBarClass
 
 	#pragma warning disable CS8618
 	public DummyBarClass(int value)
+		: base(value)
 	{
-		Value = value;
 	}
 
 	public DummyBarClass(string otherValue, int value)
+		: base(value)
 	{
-		Value = value;
 	}
 	#pragma warning restore CS8618
 

--- a/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyFooBase.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyFooBase.cs
@@ -1,0 +1,10 @@
+﻿namespace Testably.Architecture.Rules.Tests.TestHelpers;
+
+internal class DummyFooBase
+{
+	public int Value { get; }
+	public DummyFooBase(int value)
+	{
+		Value = value;
+	}
+}

--- a/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyFooClass.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/TestHelpers/DummyFooClass.cs
@@ -4,11 +4,10 @@
 // ReSharper disable UnusedMember.Local
 // ReSharper disable UnusedParameter.Local
 [DummyFoo]
-internal class DummyFooClass
+internal class DummyFooClass : DummyFooBase
 {
 	public int? DummyFooProperty1 { get; set; }
 	public int? DummyFooProperty2 { get; set; }
-	public int Value { get; }
 
 	public delegate void DummyFoo();
 
@@ -29,13 +28,13 @@ internal class DummyFooClass
 
 	#pragma warning disable CS8618
 	public DummyFooClass(int value)
+		: base(value)
 	{
-		Value = value;
 	}
 
 	public DummyFooClass(string otherValue, int value)
+		: base(value)
 	{
-		Value = value;
 	}
 	#pragma warning restore CS8618
 

--- a/Tests/Testably.Architecture.Rules.Tests/TestHelpers/ParameterCountAttribute.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/TestHelpers/ParameterCountAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Testably.Architecture.Rules.Tests.TestHelpers;
+
+[AttributeUsage(AttributeTargets.Constructor)]
+public class ParameterCountAttribute : Attribute
+{
+	public int Count { get; }
+
+	public ParameterCountAttribute(int count)
+	{
+		Count = count;
+	}
+}


### PR DESCRIPTION
Add Parameter filters for constructors, so that constructors can be filtered by its parameters, e.g.
```csharp
  Expect.That.Types
    .Which(Have.Constructor.With(Parameters.Any.OfType(typeof(ILogger<>))))
    .ShouldResideInNamespace("Foo.Bar");
```