### PR TITLE
feat: support filter for Last parameter

### DIFF
--- a/Source/Testably.Architecture.Rules/Filters/ParameterFilterExtensions.OfType.cs
+++ b/Source/Testably.Architecture.Rules/Filters/ParameterFilterExtensions.OfType.cs
@@ -165,15 +165,19 @@ public static partial class ParameterFilterExtensions
 
 		#region IOrderedParameterFilterResult Members
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="IOrderedParameterFilterResult.Apply(ParameterInfo[])" />
 		public bool Apply(ParameterInfo[] parameterInfos)
 			=> _filterResult.Apply(parameterInfos);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="IOrderedParameterFilterResult.At(int)" />
+		public IParameterFilter<IOrderedParameterFilterResult> At(int position)
+			=> _filterResult.At(position);
+
+		/// <inheritdoc cref="IOrderedParameterFilterResult.Then()" />
 		public IParameterFilter<IOrderedParameterFilterResult> Then()
 			=> _filterResult.Then();
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="IParameterFilterResult{TResult}.FriendlyName()" />
 		public override string FriendlyName()
 			=> _filterResult.FriendlyName();
 

--- a/Source/Testably.Architecture.Rules/Interfaces/IOrderedParameterFilterResult.cs
+++ b/Source/Testably.Architecture.Rules/Interfaces/IOrderedParameterFilterResult.cs
@@ -14,7 +14,18 @@ public interface IOrderedParameterFilterResult
 	bool Apply(ParameterInfo[] parameterInfos);
 
 	/// <summary>
-	///     Specifies filters on the next <see cref="ParameterInfo" />.
+	///     Specifies an explicit position of the parameter.
+	///     <para />
+	///     Positive values are zero-based index from the start.<br />
+	///     Negative values count from the last parameter back (e.g. `-1` indicates the last parameter).
+	/// </summary>
+	IParameterFilter<IOrderedParameterFilterResult> At(int position);
+
+	/// <summary>
+	///     Specifies filters on the next or previous <see cref="ParameterInfo" />.
+	///     <para />
+	///     In ascending order (when using <see cref="Parameters.First" /> the next parameter is used.<br />
+	///     In descending order (when using <see cref="Parameters.Last" /> the previous parameter is used.
 	/// </summary>
 	IParameterFilter<IOrderedParameterFilterResult> Then();
 }

--- a/Source/Testably.Architecture.Rules/Parameters.cs
+++ b/Source/Testably.Architecture.Rules/Parameters.cs
@@ -16,8 +16,8 @@ public static class Parameters
 		=> new ParameterAnyFilter();
 
 	/// <summary>
-	///     Specifies a series of filters that must be satisfied by the <see cref="ParameterInfo" />s in the correct order.
+	///     Specifies a series of filters starting at the first parameter that must be satisfied by the <see cref="ParameterInfo" />s in the correct order.
 	/// </summary>
-	public static IParameterFilter<IOrderedParameterFilterResult> InOrder
+	public static IParameterFilter<IOrderedParameterFilterResult> First
 		=> new ParameterInOrderFilter();
 }

--- a/Source/Testably.Architecture.Rules/Parameters.cs
+++ b/Source/Testably.Architecture.Rules/Parameters.cs
@@ -16,8 +16,16 @@ public static class Parameters
 		=> new ParameterAnyFilter();
 
 	/// <summary>
-	///     Specifies a series of filters starting at the first parameter that must be satisfied by the <see cref="ParameterInfo" />s in the correct order.
+	///     Specifies an incrementing series of parameter filters starting at the first parameter that must be satisfied by the
+	///     <see cref="ParameterInfo" />s in the correct order.
 	/// </summary>
 	public static IParameterFilter<IOrderedParameterFilterResult> First
 		=> new ParameterInOrderFilter();
+
+	/// <summary>
+	///     Specifies a decrementing series of parameter filters starting at the last parameter that must be satisfied by the
+	///     <see cref="ParameterInfo" />s in the correct order.
+	/// </summary>
+	public static IParameterFilter<IOrderedParameterFilterResult> Last
+		=> new ParameterInOrderFilter().At(-1);
 }

--- a/Tests/Testably.Architecture.Example.Tests/ExampleTests.cs
+++ b/Tests/Testably.Architecture.Example.Tests/ExampleTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Architecture.Example.Tests.TestHelpers;
 using Testably.Architecture.Rules;
 using Xunit;
@@ -16,6 +17,22 @@ public sealed class ExampleTests
 		IRule rule = Expect.That.Methods
 			.WithReturnType<Task>().OrReturnType(typeof(Task<>))
 			.ShouldMatchName("*Async")
+			.AllowEmpty();
+
+		rule.Check
+			.InTestAssembly()
+			.ThrowIfViolated();
+	}
+
+	/// <summary>
+	///     Methods that return Task should have <see cref="CancellationToken" /> as last parameter.
+	/// </summary>
+	[Fact]
+	public void AsyncMethodsShouldHaveCancellationTokenAsLastParameter()
+	{
+		IRule rule = Expect.That.Methods
+			.WithReturnType<Task>().OrReturnType(typeof(Task<>))
+			.ShouldHave(Parameters.Last.OfType<CancellationToken>())
 			.AllowEmpty();
 
 		rule.Check

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/ConstructorFilterExtensionsTests.Parameter.cs
@@ -33,7 +33,7 @@ public sealed partial class ConstructorFilterExtensionsTests
 				.WhichAre(typeof(TestClass)).And
 				.Which(Have.Constructor
 					.WithAttribute<ParameterCountAttribute>(p => p.Count == parameterCount).And
-					.With(Parameters.InOrder.WithName("value1").Then().WithName("value2")))
+					.With(Parameters.First.WithName("value1").Then().WithName("value2")))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/MethodFilterExtensionsTests.Parameter.cs
@@ -19,7 +19,7 @@ public sealed partial class MethodFilterExtensionsTests
 			ITestResult result = Expect.That.Types
 				.WhichAre(typeof(TestClass)).And
 				.Which(Have.Method.WhichNameMatches(methodName).And
-					.With(Parameters.InOrder.WithName("value1").Then().WithName("value2")))
+					.With(Parameters.First.WithName("value1").Then().WithName("value2")))
 				.ShouldAlwaysFail()
 				.AllowEmpty()
 				.Check.InAllLoadedAssemblies();

--- a/Tests/Testably.Architecture.Rules.Tests/Filters/ParameterFilterExtensionsTests.OfType.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Filters/ParameterFilterExtensionsTests.OfType.cs
@@ -17,7 +17,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		public void OfType_Ordered_FooBase_ShouldReturnExpectedValue(bool allowDerivedType,
 			bool expectedValue)
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			bool result = Have.Method
 				.With(
@@ -30,7 +30,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		[Fact]
 		public void OfType_Ordered_NotMatchingType_ShouldReturnFalse()
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			bool result = Have.Method
 				.With(
@@ -43,7 +43,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		[Fact]
 		public void OfType_Ordered_OrOfType_NotMatchingAndMatchingType_ShouldReturnTrue()
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			bool result = Have.Method
 				.With(
@@ -56,7 +56,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		[Fact]
 		public void OfType_Ordered_OrOfType_ToString_ShouldCombineBothTypes()
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			string result = sut.OfType<Foo>().OrOfType<Bar>().ToString();
 
@@ -68,7 +68,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		[InlineData(typeof(Bar), false)]
 		public void OfType_Ordered_ShouldReturnExpectedValue(Type type, bool expectedValue)
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			bool result = Have.Method
 				.With(
@@ -84,7 +84,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		public void OfType_Ordered_Then_ShouldGoToNextParameter(Type type1, Type type2,
 			bool expectedValue)
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			bool result = Have.Method
 				.With(sut
@@ -99,7 +99,7 @@ public sealed partial class ParameterFilterExtensionsTests
 		[Fact]
 		public void OfType_Ordered_ToString_ShouldCombineBothTypes()
 		{
-			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+			IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 			string result = sut.OfType<Foo>().ToString();
 

--- a/Tests/Testably.Architecture.Rules.Tests/Internal/ParameterInOrderFilterTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Internal/ParameterInOrderFilterTests.cs
@@ -15,7 +15,7 @@ public sealed class ParameterInOrderFilterTests
 	public void Apply_ShouldCheckEachFilterIndividually()
 	{
 		ParameterInfo[] parameters = typeof(DummyFooClass).GetConstructors()[0].GetParameters();
-		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 		IOrderedParameterFilterResult filter = sut
 			.Which(p => p == parameters.First()).And
@@ -35,7 +35,7 @@ public sealed class ParameterInOrderFilterTests
 		bool filter1Result, bool filter2Result, bool expectedResult)
 	{
 		ParameterInfo[] parameters = typeof(DummyFooClass).GetConstructors()[0].GetParameters();
-		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 		IOrderedParameterFilterResult filter = sut
 			.Which(_ => filter1Result).And
@@ -54,7 +54,7 @@ public sealed class ParameterInOrderFilterTests
 	[InlineData(4, "5th")]
 	public void FriendlyName_ShouldIncludeExpectedValue(int numberOfThen, string expectedValue)
 	{
-		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 		for (int i = 0; i < numberOfThen; i++)
 		{
@@ -72,7 +72,7 @@ public sealed class ParameterInOrderFilterTests
 	[AutoData]
 	public void FriendlyName_ShouldJoinAllFilters(string filter1, string filter2)
 	{
-		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.InOrder;
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
 		IOrderedParameterFilterResult result = sut
 			.Which(_ => false, filter1).And

--- a/Tests/Testably.Architecture.Rules.Tests/Internal/ParameterInOrderFilterTests.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Internal/ParameterInOrderFilterTests.cs
@@ -12,6 +12,46 @@ namespace Testably.Architecture.Rules.Tests.Internal;
 public sealed class ParameterInOrderFilterTests
 {
 	[Fact]
+	public void Apply_First_Then_ShouldIncrementIndex()
+	{
+		ParameterInfo[] parameters = typeof(ParameterInOrderFilterTests)
+			.GetMethod(nameof(DummyMethod))!
+			.GetParameters();
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
+
+		IOrderedParameterFilterResult filter = sut
+			.Which(p => p == parameters[0]).Then()
+			.Which(p => p == parameters[1]).Then()
+			.Which(p => p == parameters[2]).Then()
+			.Which(p => p == parameters[3]).Then()
+			.Which(p => p == parameters[4]);
+
+		bool result = filter.Apply(parameters);
+
+		result.Should().BeTrue();
+	}
+
+	[Fact]
+	public void Apply_Last_Then_ShouldDecrementIndex()
+	{
+		ParameterInfo[] parameters = typeof(ParameterInOrderFilterTests)
+			.GetMethod(nameof(DummyMethod))!
+			.GetParameters();
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.Last;
+
+		IOrderedParameterFilterResult filter = sut
+			.Which(p => p == parameters[4]).Then()
+			.Which(p => p == parameters[3]).Then()
+			.Which(p => p == parameters[2]).Then()
+			.Which(p => p == parameters[1]).Then()
+			.Which(p => p == parameters[0]);
+
+		bool result = filter.Apply(parameters);
+
+		result.Should().BeTrue();
+	}
+
+	[Fact]
 	public void Apply_ShouldCheckEachFilterIndividually()
 	{
 		ParameterInfo[] parameters = typeof(DummyFooClass).GetConstructors()[0].GetParameters();
@@ -47,12 +87,13 @@ public sealed class ParameterInOrderFilterTests
 	}
 
 	[Theory]
-	[InlineData(0, "1st")]
-	[InlineData(1, "2nd")]
-	[InlineData(2, "3rd")]
-	[InlineData(3, "4th")]
-	[InlineData(4, "5th")]
-	public void FriendlyName_ShouldIncludeExpectedValue(int numberOfThen, string expectedValue)
+	[InlineData(0, "1st parameter")]
+	[InlineData(1, "2nd parameter")]
+	[InlineData(2, "3rd parameter")]
+	[InlineData(3, "4th parameter")]
+	[InlineData(4, "5th parameter")]
+	public void FriendlyName_First_ShouldIncludeExpectedValue(int numberOfThen,
+		string expectedValue)
 	{
 		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.First;
 
@@ -66,6 +107,39 @@ public sealed class ParameterInOrderFilterTests
 
 		result.FriendlyName().Should()
 			.Contain(expectedValue);
+	}
+
+	[Theory]
+	[InlineData(1, "2nd to last parameter")]
+	[InlineData(2, "3rd to last parameter")]
+	[InlineData(3, "4th to last parameter")]
+	[InlineData(4, "5th to last parameter")]
+	public void FriendlyName_Last_ShouldIncludeExpectedValue(int numberOfThen, string expectedValue)
+	{
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.Last;
+
+		for (int i = 0; i < numberOfThen; i++)
+		{
+			sut = sut.Which(_ => true).Then();
+		}
+
+		IOrderedParameterFilterResult result = sut
+			.Which(_ => true);
+
+		result.FriendlyName().Should()
+			.Contain(expectedValue);
+	}
+
+	[Fact]
+	public void FriendlyName_OnlyLast_ShouldStartWithLastParameter()
+	{
+		IParameterFilter<IOrderedParameterFilterResult> sut = Parameters.Last;
+
+		IOrderedParameterFilterResult result = sut
+			.Which(_ => true);
+
+		result.FriendlyName().Should()
+			.StartWith("last parameter");
 	}
 
 	[Theory]
@@ -86,7 +160,7 @@ public sealed class ParameterInOrderFilterTests
 
 	#region Helpers
 
-	private static void DummyMethod(int v1, int v2, int v3, int v4, int v5)
+	public void DummyMethod(int v1, int v2, int v3, int v4, int v5)
 	{
 		// Do nothing
 	}

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.HaveParameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnConstructorExtensionsTests.HaveParameter.cs
@@ -49,7 +49,7 @@ public sealed partial class RequirementOnConstructorExtensionsTests
 				.First(p => p.GetParameters().Length == parameterCount);
 			IRule rule = Expect.That.Constructors
 				.WhichAre(constructor)
-				.ShouldHave(Parameters.InOrder
+				.ShouldHave(Parameters.First
 					.OfType<string>().Then()
 					.OfType<int>());
 

--- a/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.HaveParameter.cs
+++ b/Tests/Testably.Architecture.Rules.Tests/Requirements/RequirementOnMethodExtensionsTests.HaveParameter.cs
@@ -47,7 +47,7 @@ public sealed partial class RequirementOnMethodExtensionsTests
 				.GetMethod(methodName)!;
 			IRule rule = Expect.That.Methods
 				.WhichAre(method)
-				.ShouldHave(Parameters.InOrder
+				.ShouldHave(Parameters.First
 					.OfType<string>().Then()
 					.OfType<int>());
 


### PR DESCRIPTION
Add an option to specify parameter filters in descending order.
Rename `InOrder` to `First` and add another option `Last` to the `Parameters` class.

This allows specifying e.g. the following test:
```csharp
	/// <summary>
	///     Methods that return Task should have <see cref="CancellationToken" /> as last parameter.
	/// </summary>
	[Fact]
	public void AsyncMethodsShouldHaveCancellationTokenAsLastParameter()
	{
		IRule rule = Expect.That.Methods
			.WithReturnType<Task>().OrReturnType(typeof(Task<>))
			.ShouldHave(Parameters.Last.OfType<CancellationToken>())
			.AllowEmpty();

		rule.Check
			.InTestAssembly()
			.ThrowIfViolated();
	}
```