### PR TITLE
fix: exclude `DynamicProxyGenAssembly2` assemblies from Castle

### DIFF
--- a/Source/Testably.Architecture.Rules/ExclusionLists.cs
+++ b/Source/Testably.Architecture.Rules/ExclusionLists.cs
@@ -21,7 +21,9 @@ public static class ExclusionLists
 			"mscorlib",
 			"System",
 			"Microsoft",
-			"xunit"
+			"xunit",
+			"Castle",
+			"DynamicProxyGenAssembly2"
 		};
 
 	/// <summary>


### PR DESCRIPTION
[Castle Dynamic Proxy](http://www.castleproject.org/projects/dynamicproxy/) creates a dynamic assembly which should not be included per default in the architecture tests.