### PR TITLE
refactor: remove dependency on Moq

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -24,7 +24,6 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
 		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Moq" Version="4.20.69" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 		<PackageReference Include="Xunit.SkippableFact" Version="1.4.*" />
 		<PackageReference Include="xunit" Version="2.5.0" />


### PR DESCRIPTION
Remove dependency on Moq due to its dependency on SponsorLink (see https://github.com/moq/moq/issues/1374)